### PR TITLE
fix(initContainers): render initContainer properly with map values

### DIFF
--- a/scraparr/templates/deployment.yaml
+++ b/scraparr/templates/deployment.yaml
@@ -34,6 +34,7 @@ spec:
       {{- range $key, $values := $.Values.config }}
       {{- if regexMatch "radarr|sonarr|prowlarr$" $key }}
       {{- $arrInfo := get $.Values.config $key }}
+      {{- if kindIs "slice" $arrInfo }}
       {{- range $service := $values }}
         - name: wait-for-{{ $service.alias }}
           image: busybox:1.37.0
@@ -41,6 +42,15 @@ spec:
             "sh",
             "-c",
             "for i in $(seq 30); do if (wget --spider -S -T 10 \"{{ $service.url }}\" 2>&1 | grep -qw '200\\|301\\|302' > /dev/null) ; then exit 0; fi; echo [$i] Waiting for {{ $service.alias }}; sleep 10; done; echo Timed out waiting for {{ $service.alias }}; exit 1"
+          ]
+      {{- end }}
+      {{- else if kindIs "map" $arrInfo }}
+        - name: wait-for-{{ $key }}
+          image: busybox:1.37.0
+          command: [
+            "sh",
+            "-c",
+            "for i in $(seq 30); do if (wget --spider -S -T 10 \"{{ $arrInfo.url }}\" 2>&1 | grep -qw '200\\|301\\|302' > /dev/null) ; then exit 0; fi; echo [$i] Waiting for {{ $key }}; sleep 10; done; echo Timed out waiting for {{ $key }}; exit 1"
           ]
       {{- end }}
       {{- end }}


### PR DESCRIPTION
#### Please check if the PR fulfills these requirements
- [x] The branch naming convention follows our guidelines
- [x] Docs have been added / updated (for bug fixes / features)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Bug fix

#### What is the current behavior? (You can also link to an open issue here)

InitContainers were not being rendering when the *arr system values were not a list but a map.

#### What is the new behavior (if this is a feature change)?

Whenever the user uses either the List or Map type, InitContainers are rendered.

#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

#### Other information:

None

<!-- By submitting this Pull Request, you agree to follow our [Code of Conduct](https://github.com/imgios/scraparr/blob/main/CONTRIBUTING.md) -->
