### PR TITLE
Add initContainers also for Bazarr, Readarr, Overseerr and Jellyseerr

### DIFF
--- a/scraparr/templates/deployment.yaml
+++ b/scraparr/templates/deployment.yaml
@@ -29,10 +29,10 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if and .Values.config (or .Values.config.radarr .Values.config.sonarr .Values.config.prowlarr) }}
+      {{- if and .Values.config (or .Values.config.radarr .Values.config.sonarr .Values.config.prowlarr .Values.config.bazarr .Values.config.readarr .Values.config.jellyseerr .Values.config.overseerr) }}
       initContainers:
       {{- range $key, $values := $.Values.config }}
-      {{- if regexMatch "radarr|sonarr|prowlarr$" $key }}
+      {{- if regexMatch "radarr|sonarr|prowlarr|bazarr|readarr|jellyseerr|overseerr$" $key }}
       {{- $arrInfo := get $.Values.config $key }}
       {{- if kindIs "slice" $arrInfo }}
       {{- range $service := $values }}


### PR DESCRIPTION
#### Please check if the PR fulfills these requirements
- [x] The branch naming convention follows our guidelines
- [x] Docs have been added / updated (for bug fixes / features)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Feature

#### What is the current behavior? (You can also link to an open issue here)

The initContainers are spawn only for radarr, sonarr and prowlarr

#### What is the new behavior (if this is a feature change)?

InitContainers spawned also for Bazarr, Readarr, Overseerr and Jellyseerr.

#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

#### Other information:

None

<!-- By submitting this Pull Request, you agree to follow our [Code of Conduct](https://github.com/imgios/scraparr/blob/main/CONTRIBUTING.md) -->
