### PR TITLE
Add missing 2.2 integration values

### DIFF
--- a/scraparr/Chart.yaml
+++ b/scraparr/Chart.yaml
@@ -15,6 +15,7 @@ keywords:
   - jellyseerr
   - jellyfin
   - flaresolverr
+  - whisparr
 home: https://github.com/imgios/scraparr
 sources:
   - https://github.com/imgios/scraparr

--- a/scraparr/Chart.yaml
+++ b/scraparr/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: scraparr
 description: Scraparr is a Prometheus Exporter for various components of the *arr Suite
 type: application
-version: 1.2.2
+version: 1.2.3
 appVersion: "2.2.0"
 keywords:
   - arr

--- a/scraparr/README.md
+++ b/scraparr/README.md
@@ -1,4 +1,4 @@
-![Version: 1.2.2](https://img.shields.io/badge/Version-1.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.0](https://img.shields.io/badge/AppVersion-2.2.0-informational?style=flat-square) 
+![Version: 1.2.3](https://img.shields.io/badge/Version-1.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.0](https://img.shields.io/badge/AppVersion-2.2.0-informational?style=flat-square) 
 
 # scraparr
 
@@ -34,12 +34,14 @@ Scraparr is a Prometheus Exporter for various components of the *arr Suite
 | config.auth.password | string | `s3cr3t1Gu3ss` | Insert the Scraparr password to be configured if opt for the basic authentication. |
 | config.auth.username | string | `scraparr` | Insert the Scraparr username to be configured if opt for the basic authentication. |
 | config.bazarr | list | `{}` | This is the bazarr instances list. You have to define URL, API KEY and alias for each entry. The alias is mandatory if configuring more than one bazarr instance. See [thecfu's scraparr repository](https://github.com/thecfu/scraparr) for more info. |
+| config.jellyfin | list | `{}` | This is the jellyfin instances list. You have to define URL, API KEY and alias for each entry. The alias is mandatory if configuring more than one jellyfin instance. See [thecfu's scraparr repository](https://github.com/thecfu/scraparr) for more info. |
 | config.jellyseerr | list | `{}` | This is the jellyseerr instances list. You have to define URL, API KEY and alias for each entry. The alias is mandatory if configuring more than one jellyseerr instance. See [thecfu's scraparr repository](https://github.com/thecfu/scraparr) for more info. |
 | config.overseerr | list | `{}` | This is the overseerr instances list. You have to define URL, API KEY and alias for each entry. The alias is mandatory if configuring more than one overseerr instance. See [thecfu's scraparr repository](https://github.com/thecfu/scraparr) for more info. |
 | config.prowlarr | list | `{}` | This is the prowlarr instances list. You have to define URL, API KEY and alias for each entry. The alias is mandatory if configuring more than one prowlarr instance. See [thecfu's scraparr repository](https://github.com/thecfu/scraparr) for more info. |
 | config.radarr | list | `{}` | This is the radarr instances list. You have to define URL, API KEY and alias for each entry. The alias is mandatory if configuring more than one radarr instance. See [thecfu's scraparr repository](https://github.com/thecfu/scraparr) for more info. |
 | config.readarr | list | `{}` | This is the readarr instances list. You have to define URL, API KEY and alias for each entry. The alias is mandatory if configuring more than one readarr instance. See [thecfu's scraparr repository](https://github.com/thecfu/scraparr) for more info. |
 | config.sonarr | list | `{}` | This is the sonarr instances list. You have to define URL, API KEY and alias for each entry. The alias is mandatory if configuring more than one sonarr instance. See [thecfu's scraparr repository](https://github.com/thecfu/scraparr) for more info. |
+| config.whisparr | list | `{}` | This is the whisparr instances list. You have to define URL, API KEY and alias for each entry. The alias is mandatory if configuring more than one whisparr instance. See [thecfu's scraparr repository](https://github.com/thecfu/scraparr) for more info. |
 
 ### Chart Configuration
 

--- a/scraparr/values.yaml
+++ b/scraparr/values.yaml
@@ -89,7 +89,7 @@ config:
   # -- (list) This is the jellyfin instances list. You have to define URL, API KEY and alias for each entry. The alias is mandatory if configuring more than one jellyfin instance. See [thecfu's scraparr repository](https://github.com/thecfu/scraparr) for more info.
   # @section -- Scraparr Configuration
   jellyfin: {}
-    # - url: http://jellyfin:8096
+    # - url: http://jellyfin.media.cluster.local:8096
     #   api_key: key123
     #   alias: jellyfin
     #   interval: 30

--- a/scraparr/values.yaml
+++ b/scraparr/values.yaml
@@ -86,6 +86,15 @@ config:
     #   alias: whisparr
     #   interval: 30
     #   detailed: true
+  # -- (list) This is the jellyfin instances list. You have to define URL, API KEY and alias for each entry. The alias is mandatory if configuring more than one jellyfin instance. See [thecfu's scraparr repository](https://github.com/thecfu/scraparr) for more info.
+  # @section -- Scraparr Configuration
+  jellyfin: {}
+    # - url: http://jellyfin:8096
+    #   api_key: key123
+    #   alias: jellyfin
+    #   interval: 30
+    #   within: 30
+    #   detailed: true
 
 # -- (string) This is the number of Scraparr deployment replicas.
 # @default -- `1`

--- a/scraparr/values.yaml
+++ b/scraparr/values.yaml
@@ -78,6 +78,14 @@ config:
   #     api_version: v3
   #     interval: 30
   #     detailed: true
+  # -- (list) This is the whisparr instances list. You have to define URL, API KEY and alias for each entry. The alias is mandatory if configuring more than one whisparr instance. See [thecfu's scraparr repository](https://github.com/thecfu/scraparr) for more info.
+  # @section -- Scraparr Configuration
+  whisparr: {}
+    # - url: http://whisparr.media.cluster.local:6969
+    #   api_key: key123
+    #   alias: whisparr
+    #   interval: 30
+    #   detailed: true
 
 # -- (string) This is the number of Scraparr deployment replicas.
 # @default -- `1`


### PR DESCRIPTION
#### Please check if the PR fulfills these requirements
- [x] The branch naming convention follows our guidelines
- [x] Docs have been added / updated (for bug fixes / features)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Hot fix

#### What is the current behavior? (You can also link to an open issue here)

Scraparr software version has been updated to 2.2.0, but the Chart is missing the new integrations values.

#### What is the new behavior (if this is a feature change)?

The now has the newest integrations values (`whisparr` and `jellyfin`) and the chart version is bumped to `1.2.3`

#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

#### Other information:

None

<!-- By submitting this Pull Request, you agree to follow our [Code of Conduct](https://github.com/imgios/scraparr/blob/main/CONTRIBUTING.md) -->
