### PR TITLE
feat(chart): allow to create a service monitor

### DIFF
--- a/scraparr/README.md
+++ b/scraparr/README.md
@@ -58,6 +58,19 @@ Scraparr is a Prometheus Exporter for various components of the *arr Suite
 | ingress.tls | string | `[]` | Ingress certificates for secure protocols (e.g., HTTPS) |
 | nodeSelector | string | `{}` | This parameter is useful to deploy Scraparr only on a given set of nodes. |
 | replicaCount | string | `1` | This is the number of Scraparr deployment replicas. |
+| service.annotations | object | `{}` | Service annotations |
+| service.port | int | `7100` | Service port |
+| service.type | string | `ClusterIP` | Service type (ClusterIP, NodePort, LoadBalancer) |
+| serviceMonitor.annotations | object | `{}` | ServiceMonitor annotations |
+| serviceMonitor.basicAuth | object | `{}` | Basic auth configuration for scraping |
+| serviceMonitor.enabled | bool | `false` | Enable ServiceMonitor for Prometheus Operator |
+| serviceMonitor.interval | string | `30s` | Prometheus scrape interval |
+| serviceMonitor.labels | object | `{}` | Additional labels for the ServiceMonitor |
+| serviceMonitor.metricRelabelings | list | `[]` | Prometheus metric relabel configs |
+| serviceMonitor.path | string | `/metrics` | Metrics path |
+| serviceMonitor.relabelings | list | `[]` | Prometheus relabel configs |
+| serviceMonitor.scrapeTimeout | string | `10s` | Prometheus scrape timeout |
+| serviceMonitor.targetLabels | string | `[]` | Target labels (comma separated) |
 
 
 ----------------------------------------------

--- a/scraparr/templates/service.yaml
+++ b/scraparr/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "scraparr.fullname" . }}
   labels:
     {{- include "scraparr.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/scraparr/templates/servicemonitor.yaml
+++ b/scraparr/templates/servicemonitor.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "scraparr.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "scraparr.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "scraparr.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      {{- if .Values.serviceMonitor.path }}
+      path: {{ .Values.serviceMonitor.path }}
+      {{- end }}
+      {{- if .Values.serviceMonitor.interval }}
+      interval: {{ .Values.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.basicAuth }}
+      basicAuth:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- with .Values.serviceMonitor.targetLabels }}
+  targetLabels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+

--- a/scraparr/values.yaml
+++ b/scraparr/values.yaml
@@ -137,10 +137,60 @@ securityContext: {}
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
   # runAsUser: 1000
-# @ignore
 service:
+  # -- (string) Service type (ClusterIP, NodePort, LoadBalancer)
+  # @default -- `ClusterIP`
+  # @section -- Chart Configuration
   type: ClusterIP
+  # -- (int) Service port
+  # @default -- `7100`
+  # @section -- Chart Configuration
   port: 7100
+  # -- (object) Service annotations
+  # @section -- Chart Configuration
+  annotations: {}
+
+serviceMonitor:
+  # -- (bool) Enable ServiceMonitor for Prometheus Operator
+  # @default -- `false`
+  # @section -- Chart Configuration
+  enabled: false
+  # -- (object) Additional labels for the ServiceMonitor
+  # @section -- Chart Configuration
+  labels: {}
+  # -- (object) ServiceMonitor annotations
+  # @section -- Chart Configuration
+  annotations: {}
+  # -- (string) Prometheus scrape interval
+  # @default -- `30s`
+  # @section -- Chart Configuration
+  interval: 30s
+  # -- (string) Prometheus scrape timeout
+  # @default -- `10s`
+  # @section -- Chart Configuration
+  scrapeTimeout: 10s
+  # -- (string) Metrics path
+  # @default -- `/metrics`
+  # @section -- Chart Configuration
+  path: /metrics
+  # -- (list) Prometheus relabel configs
+  # @section -- Chart Configuration
+  relabelings: []
+  # -- (list) Prometheus metric relabel configs
+  # @section -- Chart Configuration
+  metricRelabelings: []
+  # -- (string) Target labels (comma separated)
+  # @section -- Chart Configuration
+  targetLabels: []
+  # -- (object) Basic auth configuration for scraping
+  # @section -- Chart Configuration
+  basicAuth: {}
+    # username:
+    #   name: scraparr-basic-auth
+    #   key: username
+    # password:
+    #   name: scraparr-basic-auth
+    #   key: password
 
 ingress:
   # -- (string) Enable scraparr ingress to reach it out via FQDN. This may be necessary in some circumstances.


### PR DESCRIPTION
#### Please check if the PR fulfills these requirements
- [x] The branch naming convention follows our guidelines
- [x] Docs have been added / updated (for bug fixes / features)

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

Include the service monitor creation in the chart 

#### What is the new behavior (if this is a feature change)?

The chart is now allowing to create a prometheus operator ServiceMonitor and specify annotations on the service 

#### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Nope

#### Other information:


<!-- By submitting this Pull Request, you agree to follow our [Code of Conduct](https://github.com/imgios/scraparr/blob/main/CONTRIBUTING.md) -->
