### PR TITLE
feat(secrets): add secrets support from configMapRef e secretKeyRef

### DIFF
--- a/scraparr/templates/_helpers.tpl
+++ b/scraparr/templates/_helpers.tpl
@@ -60,3 +60,37 @@ Scraparr metrics endpoint
 {{- printf "/metrics" }}
 {{- end }}
 {{- end }}
+
+{{/*
+Process the scraparr config, transforming structured api_key objects:
+  - type "literal": replaced with the plain string value (api_key.value)
+  - type "ref":     replaced with ${api_key.name} for env var interpolation
+  - plain string:   passed through unchanged (backward compatible)
+*/}}
+{{- define "scraparr.processConfig" -}}
+{{- $result := dict -}}
+{{- range $service, $instances := . -}}
+  {{- if kindIs "slice" $instances -}}
+    {{- $newInstances := list -}}
+    {{- range $instance := $instances -}}
+      {{- $newInstance := dict -}}
+      {{- range $k, $v := $instance -}}
+        {{- if and (eq $k "api_key") (kindIs "map" $v) -}}
+          {{- if eq $v.type "literal" -}}
+            {{- $newInstance = set $newInstance "api_key" $v.value -}}
+          {{- else if eq $v.type "ref" -}}
+            {{- $newInstance = set $newInstance "api_key" (printf "${%s}" $v.name) -}}
+          {{- end -}}
+        {{- else -}}
+          {{- $newInstance = set $newInstance $k $v -}}
+        {{- end -}}
+      {{- end -}}
+      {{- $newInstances = append $newInstances $newInstance -}}
+    {{- end -}}
+    {{- $result = set $result $service $newInstances -}}
+  {{- else -}}
+    {{- $result = set $result $service $instances -}}
+  {{- end -}}
+{{- end -}}
+{{- $result | toYaml -}}
+{{- end }}

--- a/scraparr/templates/configmap.yaml
+++ b/scraparr/templates/configmap.yaml
@@ -4,4 +4,4 @@ metadata:
   name: scraparr-config
 data:
   config.yaml: |-
-  {{- .Values.config | toYaml | nindent 4 }}
+  {{- include "scraparr.processConfig" .Values.config | nindent 4 }}

--- a/scraparr/templates/deployment.yaml
+++ b/scraparr/templates/deployment.yaml
@@ -84,22 +84,9 @@ spec:
               {{- end -}}
             {{- end -}}
           {{- end -}}
-          {{- if or .Values.env .Values.extraEnv $apiKeyEnvVars }}
+          {{- if $apiKeyEnvVars }}
           env:
-            {{- range $key, $value := .Values.env }}
-            - name: {{ $key | quote }}
-              value: {{ $value | quote }}
-            {{- end }}
-            {{- if $apiKeyEnvVars }}
-              {{- $apiKeyEnvVars | toYaml | nindent 12 }}
-            {{- end }}
-            {{- with .Values.extraEnv }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
-          {{- end }}
-          {{- with .Values.envFrom }}
-          envFrom:
-            {{- toYaml . | nindent 12 }}
+            {{- $apiKeyEnvVars | toYaml | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/scraparr/templates/deployment.yaml
+++ b/scraparr/templates/deployment.yaml
@@ -74,6 +74,33 @@ spec:
           readinessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- $apiKeyEnvVars := list -}}
+          {{- range $service, $instances := .Values.config -}}
+            {{- if kindIs "slice" $instances -}}
+              {{- range $instance := $instances -}}
+                {{- if and $instance.api_key (kindIs "map" $instance.api_key) (eq $instance.api_key.type "ref") -}}
+                  {{- $apiKeyEnvVars = append $apiKeyEnvVars (dict "name" $instance.api_key.name "valueFrom" $instance.api_key.valueFrom) -}}
+                {{- end -}}
+              {{- end -}}
+            {{- end -}}
+          {{- end -}}
+          {{- if or .Values.env .Values.extraEnv $apiKeyEnvVars }}
+          env:
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key | quote }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- if $apiKeyEnvVars }}
+              {{- $apiKeyEnvVars | toYaml | nindent 12 }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/scraparr/values.yaml
+++ b/scraparr/values.yaml
@@ -302,32 +302,4 @@ tolerations: []
 # @ignore
 affinity: {}
 
-# -- (map) Environment variables as plain key/value pairs injected into the Scraparr container.
-# Useful for non-sensitive configuration. For secrets, prefer `extraEnv` with `valueFrom` or `envFrom`.
-# @section -- Chart Configuration
-# @default -- `{}`
-env: {}
-# MY_VAR: my-value
 
-# -- (list) Additional environment variables in full Kubernetes `env` spec format.
-# Supports `value`, `valueFrom.secretKeyRef`, and `valueFrom.configMapKeyRef`.
-# @section -- Chart Configuration
-extraEnv: []
-# - name: SCRAPARR_API_KEY
-#   valueFrom:
-#     secretKeyRef:
-#       name: scraparr-secrets
-#       key: api_key
-# - name: SCRAPARR_TOKEN
-#   valueFrom:
-#     configMapKeyRef:
-#       name: scraparr-config-extra
-#       key: token
-
-# -- (list) Inject all keys from a Secret or ConfigMap as environment variables via `envFrom`.
-# @section -- Chart Configuration
-envFrom: []
-# - secretRef:
-#     name: scraparr-secrets
-# - configMapRef:
-#     name: scraparr-extra-config

--- a/scraparr/values.yaml
+++ b/scraparr/values.yaml
@@ -4,6 +4,24 @@
 config:
   # general:
   #   path: /metrics
+  #
+  # api_key can be specified in three ways for any service instance:
+  #   1. Plain string (backward compatible):
+  #      api_key: key123
+  #   2. Structured literal:
+  #      api_key:
+  #        type: literal
+  #        value: key123
+  #   3. Reference to a Kubernetes Secret or ConfigMap (keeps secrets out of the ConfigMap):
+  #      api_key:
+  #        type: ref
+  #        name: SONARR_API_KEY        # env var name injected into the pod
+  #        valueFrom:
+  #          secretKeyRef:             # or configMapKeyRef
+  #            name: my-secret
+  #            key: sonarr_api_key
+  #      The chart injects the env var and writes ${SONARR_API_KEY} in the config file.
+  #      Requires scraparr to support env var interpolation in its config.
   auth:
     # -- (string) Insert the Scraparr username to be configured if opt for the basic authentication.
     # @default -- `scraparr`
@@ -283,3 +301,33 @@ nodeSelector: {}
 tolerations: []
 # @ignore
 affinity: {}
+
+# -- (map) Environment variables as plain key/value pairs injected into the Scraparr container.
+# Useful for non-sensitive configuration. For secrets, prefer `extraEnv` with `valueFrom` or `envFrom`.
+# @section -- Chart Configuration
+# @default -- `{}`
+env: {}
+# MY_VAR: my-value
+
+# -- (list) Additional environment variables in full Kubernetes `env` spec format.
+# Supports `value`, `valueFrom.secretKeyRef`, and `valueFrom.configMapKeyRef`.
+# @section -- Chart Configuration
+extraEnv: []
+# - name: SCRAPARR_API_KEY
+#   valueFrom:
+#     secretKeyRef:
+#       name: scraparr-secrets
+#       key: api_key
+# - name: SCRAPARR_TOKEN
+#   valueFrom:
+#     configMapKeyRef:
+#       name: scraparr-config-extra
+#       key: token
+
+# -- (list) Inject all keys from a Secret or ConfigMap as environment variables via `envFrom`.
+# @section -- Chart Configuration
+envFrom: []
+# - secretRef:
+#     name: scraparr-secrets
+# - configMapRef:
+#     name: scraparr-extra-config


### PR DESCRIPTION
#### Please check if the PR fulfills these requirements
- [ ] The branch naming convention follows our guidelines
- [ ] Docs have been added / updated (for bug fixes / features)

TO BE MERGED: after https://github.com/imgios/scraparr/pull/29

#### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
add secrets ref env and envFrom , configmap or secrets

#### What is the current behavior? (You can also link to an open issue here)
https://github.com/imgios/scraparr/issues/27

#### What is the new behavior (if this is a feature change)?
  `api_key` can be specified in three ways for any service instance:
     1. Plain string (backward compatible):
        `api_key: key123`
     2. Structured literal:
```
        api_key:
          type: literal
          value: key123
```
3. Reference to a Kubernetes Secret or ConfigMap (keeps secrets out of the ConfigMap):
```
        api_key:
          type: ref
          name: SONARR_API_KEY        # env var name injected into the pod
          valueFrom:
            secretKeyRef:             # or configMapKeyRef
              name: my-secret
              key: sonarr_api_key
```
   The chart injects the env var and writes ${SONARR_API_KEY} in the config file.
  Requires scraparr to support env var interpolation in its config.


<!-- By submitting this Pull Request, you agree to follow our [Code of Conduct](https://github.com/imgios/scraparr/blob/main/CONTRIBUTING.md) -->
